### PR TITLE
#161254675 Pagination support for articles

### DIFF
--- a/authors/apps/article/views.py
+++ b/authors/apps/article/views.py
@@ -4,10 +4,13 @@ from .serializers import (
     ArticleCreateSerializer,
     RateArticleSerializer
 )
+
 from ..core.permissions import IsOwnerOrReadOnly
 from ..authentication.renderers import UserJSONRenderer
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
+from authors import settings
 from django.db.models import Q
 from rest_framework.generics import (
     ListAPIView, CreateAPIView,
@@ -23,15 +26,20 @@ from .models import RateArticle, Article
 LOOKUP_FIELD = 'slug'
 
 
+class StandardPagination(PageNumberPagination):
+    page_size = settings.PAGE_SIZE
+    page_size_query_param = 'page_size'
+
+
+
 class ArticleListAPIView(ListAPIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
     serializer_class = ArticleSerializer
+    pagination_class = StandardPagination
 
     def get_queryset(self, *args, **kwargs):
         queryset_list = TABLE.objects.all()
-
         query = self.request.GET.get('q')
-
         if query:
             queryset_list = queryset_list.filter(
                 Q(title__icontains=query) |

--- a/authors/settings.py
+++ b/authors/settings.py
@@ -148,6 +148,10 @@ EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
 EMAIL_PORT = os.environ['EMAIL_PORT']
 EMAIL_USE_TLS = True
 DEFAULT_DOMAIN = os.getenv('DEFAULT_DOMAIN')
+# article pagination credentials
+PAGE_SIZE = os.environ["PAGE_SIZE"]
+
+
 # Password validation
 # https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
@@ -203,7 +207,8 @@ REST_FRAMEWORK = {
 
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'authors.apps.authentication.backends.JWTAuthentication',
-    )
+    ),
+
 }
 
 SWAGGER_SETTINGS = {


### PR DESCRIPTION

#### What does this PR do?
- This PR implements pagination support articles.

#### Description of Task to be completed?
- Implements pagination of articles in the /api/articles/ endpoint
- The return json output will include a value for the count of articles, the next page and the previous page.

#### How should this be manually tested?
* Clone this repo:
```git clone https://github.com/andela/ah-orcas```
* Navigate to this branch
``` git checkout ft-pagination-161254675```
* Setup the environment variables, database and install the requirements. 
```$ source .env```
* Start the server
```$ python manage.py runserver```
- Hit the GET endpoint in postman
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/cf46eeb442114295a580)

#### What are the relevant pivotal tracker stories?
[#161254675](https://www.pivotaltracker.com/n/projects/2205267/stories/161254675)
#### Screeshots
![image](https://user-images.githubusercontent.com/25586421/48333565-fa973180-e668-11e8-818b-d0d9a8a4f270.png)

![image](https://user-images.githubusercontent.com/25586421/48333582-0a167a80-e669-11e8-84c1-96e2b7599954.png)

