### PR TITLE
#161254677 Time taken to read an article

### DIFF
--- a/authors/apps/article/tests/test_article.py
+++ b/authors/apps/article/tests/test_article.py
@@ -43,10 +43,22 @@ class TestArticles(TestCase):
                                self.user.token())
 
         self.namespace = 'article'
+        text = "Will it rain, Will it rain today, " \
+            "Will it rain today Will it rain today " \
+            "Will it rain today Will it rain today, " \
+            "Will it rain today Will it rain today " \
+            "Will it rain today Will it rain today " \
+            "Will it rain today Will it rain today," \
+            "Will it rain today Will it rain today Will it rain "
         self.body = {
             'title': faker.name(),
             'description': faker.text(),
             'body': faker.text(),
+        }
+        self.article_body = {
+            "title": "Test reading time 300 ",
+            "description": "Is a new day again?",
+            "body": text
         }
         self.create_url = reverse(self.namespace + ':create')
         self.list_url = reverse(self.namespace + ':list')
@@ -65,7 +77,12 @@ class TestArticles(TestCase):
 
     def test_create_article_api(self):
         response = self.client.post(self.create_url, self.body, format='json')
+        response1 = self.client.post(
+            self.create_url,
+            self.article_body,
+            format='json')
         self.assertEqual(201, response.status_code)
+        self.assertIn('2mins', str(response1.data))
 
     def test_retrieve_article_api(self):
         response = self.client.get(self.retrieve_url)


### PR DESCRIPTION
#### What does this PR do?
```Adds the time taken to read an article whenever it is created```
#### Description of Task to be completed?
```Whenever a user posts an article, he/she should be able to see the estimated time taken to read it ```
#### How should this be manually tested?
- Clone this repo
```$ git clone https://github.com/andela/ah-orcas```
- Navigate to this branch
```$ git checkout ft-time-to-read-161254677```
- Setup the environment variables, database and install the requirements. See sample.env
```$ source .env```
- Start the server
```$ python manage.py runserver```
- Test the endpoint for creating an article on Postman
- endpoint : http://localhost:8000/api/article/create
 - request body :
```
{
  "title": "Test reading12467890",
  "description": "Is a new day again?",
  "body": "Will it rain?
}
```
- check whether the time to read is included in the response
#### Any background context you want to provide?
```Time taken to read an article enables the article readers to know how much time they shall spend on reading the article ```
#### What are the relevant pivotal tracker stories?
[#161254677](https://www.pivotaltracker.com/story/show/161254677)
#### Screenshots 
<img width="948" alt="screen shot 2018-11-14 at 19 54 06" src="https://user-images.githubusercontent.com/11458891/48498332-18ba8880-e847-11e8-9fbb-219b6e0f8db7.png">
