### PR TITLE
#161254683 Track comments edit history

### DIFF
--- a/authors/apps/article/models.py
+++ b/authors/apps/article/models.py
@@ -184,3 +184,14 @@ class Favorite(models.Model):
         User,
         related_name="favorites",
         on_delete=models.CASCADE)
+
+
+class CommentHistory(models.Model):
+    """
+     tracks comment edit history in Authors Haven
+    """
+    comment = models.TextField()
+    original_comment = models.ForeignKey(Comments,
+                                         on_delete=models.CASCADE,
+                                         db_column='original_comment')
+    date_created = models.DateTimeField(auto_now=True)

--- a/authors/apps/article/serializers.py
+++ b/authors/apps/article/serializers.py
@@ -10,7 +10,8 @@ from django.apps import apps
 from rest_framework.validators import UniqueTogetherValidator
 
 from authors.apps.profiles.models import UserProfile
-from .models import RateArticle, Comments, Favorite
+
+from .models import RateArticle, Comments, CommentHistory, Favorite
 from authors.apps.profiles.serializers import ProfileListSerializer
 
 TABLE = apps.get_model('article', 'Article')
@@ -214,6 +215,10 @@ class CommentsSerializer(serializers.ModelSerializer):
         return instance
 
     def update(self, instance, validated_data):
+        obj = Comments.objects.only('id').get(id=instance.id)
+        updated_comment = CommentHistory.objects.create(comment=instance.body,
+                                                        original_comment=obj)
+        updated_comment.save()
         instance.body = validated_data.get('body', instance.body)
         instance.save()
         return instance
@@ -231,3 +236,10 @@ class FavoriteSerializer(serializers.ModelSerializer):
                 message="Article already favorited"
             )
         ]
+
+
+class CommentHistorySerializer(serializers.ModelSerializer):
+    """comment history serializer"""
+    class Meta:
+        model = CommentHistory
+        fields = ('id', 'comment', 'date_created', 'original_comment')

--- a/authors/apps/article/tests/test_article_comments.py
+++ b/authors/apps/article/tests/test_article_comments.py
@@ -48,7 +48,6 @@ class TestArticleComments(APITestCase):
         self.login_url = reverse('authentication:login')
         self.signup_url = reverse('authentication:register')
         self.articles_url = reverse('article:create')
-
         self.client.post(
             self.signup_url,
             self.author_details,
@@ -192,7 +191,20 @@ class TestArticleComments(APITestCase):
                 'comment_id': resp.data['id']})
         response1 = self.client.put(
             url, {'body': 'sdfsdfs sdf sdf sdfdfsdf'}, format='json')
+        response2 = self.client.get(reverse('article:comment_history', kwargs={
+            'slug': response.data.get('slug'), 'id': resp.data['id']}))
         self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+
+    def test_no_comment_history_404(self):
+        """test user should be able to update a comment for a given article"""
+        self.token = self.login()
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
+
+        # use some random id to test for 404
+        response2 = self.client.get(reverse('article:comment_history', kwargs={
+            'slug': 'some-random-slug', 'id': 123454657}))
+        self.assertEqual(response2.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_comments(self):
         """test user should be able to delete a comment for a given article"""

--- a/authors/apps/article/urls.py
+++ b/authors/apps/article/urls.py
@@ -10,14 +10,14 @@ from .views import (
     ArticleRate,
     CommentsListCreateView,
     CommentsUpdateDeleteAPIView,
-    ArticleTags)
+    ArticleTags, CommentHistoryAPIView)
 from .likes_dislike_views import (
     Like,
     Dislike,
     FavoriteAPIView
 )
 
-schema_view = get_swagger_view(title="Articles")
+schema_view = get_swagger_view(title="Article Comments")
 
 urlpatterns = [
     path(
@@ -62,6 +62,7 @@ urlpatterns = [
     path('articles/<slug:slug>/comments/<int:comment_id>',
          CommentsUpdateDeleteAPIView.as_view(),
          name='delete_comment'),
+
     path('articles/<slug>/favorite/',
          FavoriteAPIView.as_view(),
          name="favorite"),
@@ -69,4 +70,8 @@ urlpatterns = [
         "article/tag/<str:slug>",
         ArticleTags.as_view(),
         name='tag_article'),
+
+    path('articles/<slug:slug>/history/<int:id>',
+         CommentHistoryAPIView.as_view(),
+         name='comment_history'),
 ]


### PR DESCRIPTION
#### What does this PR do?
```This PR enables every comment to track its edit history ```
#### Description of Task to be completed?
```Whenever a user updates a comment, he/she should be able to track all the edit history of a particular comment ```
#### How should this be manually tested?
- Clone this repo
```$ git clone https://github.com/andela/ah-orcas```
- Navigate to this branch
```$ git checkout ft-comment-edit-history-161254683```
- Setup the environment variables, database and install the requirements. See sample.env
```$ source .env```
- Start the server
```$ python manage.py runserver```
- Open the postman below
[![Run in Postman](https://run.pstmn.io/button.svg)](https://app.getpostman.com/run-collection/989c501fef301551c967)
- Hit the POST endpoint to create a new comment
- Hit the PUT endpoint to edit the comment
- Hit the GET endpoint for getting the comment history and you will be able to see the edit history

### Any background context you want to provide?
```Edit history enables a user to track down all the edit history of a particular comment ```
#### What are the relevant pivotal tracker stories?
[#161254683](https://www.pivotaltracker.com/n/projects/2205267/stories/161254683)
#### Screenshots 
![image](https://user-images.githubusercontent.com/25586421/48501299-009a3780-e84e-11e8-994b-aea15e1e57ad.png)


